### PR TITLE
Fix Game Version desync when reopening GUI with AutoSelect enabled

### DIFF
--- a/AtlasLootClassic/GUI/GUI.lua
+++ b/AtlasLootClassic/GUI/GUI.lua
@@ -256,6 +256,7 @@ local function FrameOnShow(self)
 	if (AtlasLoot.db.enableAutoSelect) then
 		local module, instance, boss = AtlasLoot.Data.AutoSelect:GetCurrrentPlayerData()
 		local pass = false
+		local gameVersionChanged = false
 		if module and module ~= db.selected[1] then
 			self.moduleSelect:SetSelected(module)
 			pass = true
@@ -267,11 +268,33 @@ local function FrameOnShow(self)
 				pass = false
 			end
 			self.subCatSelect:SetSelected(instance)
+			if pass then
+				local moduleData = AtlasLoot.ItemDB:Get(db.selected[1])
+				if moduleData and moduleData[instance] then
+					local newGameVersion = moduleData[instance].gameVersion
+					if newGameVersion ~= db.selectedGameVersion then
+						db.selectedGameVersion = newGameVersion
+						gameVersionChanged = true
+					end
+				end
+			end
 		end
 		if AtlasLoot.db.enableAutoSelectBoss and (pass or (boss and boss ~= db.selected[3])) then
 			self.boss:SetSelected(boss or 1)
 		elseif pass then
 			self.boss:SetSelected(1)
+		end
+		if gameVersionChanged then
+			local GAME_VERSION_TEXTURES = AtlasLoot.GAME_VERSION_TEXTURES
+			if db.selectedGameVersion and GAME_VERSION_TEXTURES[db.selectedGameVersion] then
+				self.gameVersionLogo:SetTexture(GAME_VERSION_TEXTURES[db.selectedGameVersion])
+				if self.gameVersionButton.selectionFrame then
+					self.gameVersionButton.selectionFrame:Hide()
+				end
+			end
+			if LoadAtlasLootModule then
+				LoadAtlasLootModule(db.selectedGameVersion)
+			end
 		end
 		UpdateFrames(false, true) -- force a update
 	end


### PR DESCRIPTION
Description: Fixes a state desync where the GUI fails to update its internal game version after being reopened.

The issue: When manually selects a different game version and reopens the GUI while AutoSelect is active, the correct loot list is loaded, but the GUI state remains stuck on the manually selected version. This leads to:

Incorrect game version icons.

Broken dropdown menu styling.

Localization fallbacks.