### PR TITLE
Sources: initialize TooltipTextCache so early vendor scans cannot hit nil

### DIFF
--- a/AtlasLootClassic/Addons/Sources.lua
+++ b/AtlasLootClassic/Addons/Sources.lua
@@ -85,7 +85,9 @@ local PRICE_INFO_TT_START = format(TT_F.."  ", ICON_TEXTURE[3], AL["Vendor"]..":
 local DIFF_SPLIT_STRING = " / "
 
 local TooltipsHooked = false
-local TooltipCache, TooltipTextCache = {}, nil
+-- ItemSourcesUpdated() writes into TooltipTextCache unconditionally and VendorPrice.ScanShownVendor
+-- can reach it before Sources:UpdateDb() ever runs, so it must not start out nil.
+local TooltipCache, TooltipTextCache = {}, {}
 
 -- Addon
 Sources.DbDefaults = {


### PR DESCRIPTION
## Problem

Opening a vendor early after login can throw:

```
AtlasLootClassic/Addons/Sources.lua:361:
attempt to perform indexed assignment on upvalue 'TooltipTextCache' (a nil value)
[Sources.lua]:361: in function 'ItemSourcesUpdated'
[Data/VendorPrice.lua]:1340: in function 'ScanShownVendor'
```

Seen on Classic Era 1.15.9 (v3.7.10). `Sources.lua:88` declares:

```lua
local TooltipCache, TooltipTextCache = {}, nil
```

`TooltipTextCache` only becomes a table in `Sources:UpdateDb()`, but `VendorPrice.ScanShownVendor` → `ItemSourcesUpdated()` can fire before that runs, and `ItemSourcesUpdated` writes into it unconditionally.

## Change

Initialize it alongside `TooltipCache`:

```lua
local TooltipCache, TooltipTextCache = {}, {}
```

`UpdateDb()` only ever reassigns it to a fresh table (with the weak-key metatable), so this cannot change any other behavior — it just removes the pre-init nil window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
